### PR TITLE
rst-progressbar-font-color merge to master

### DIFF
--- a/src/app/progress-bar/interface_progress-bar.ts
+++ b/src/app/progress-bar/interface_progress-bar.ts
@@ -1,4 +1,5 @@
-export interface RST_PBar_Zone {
-  value: number;
-  color: string;
+export interface RSTPBarZone {
+  ProgressValue: number;
+  ProgressColor: string;
+  ProgressFontColor: string;
 }

--- a/src/app/progress-bar/progress-bar.component.html
+++ b/src/app/progress-bar/progress-bar.component.html
@@ -1,7 +1,7 @@
 <div class="rst-progressBar">
   <div class="rst-progressBar__progress" role="progressbar" [attr.name]="Name"
        [attr.aria-valuenow]="_ProgressWidth" [attr.ariavaluemin]="0" [attr.ariavaluemax]="MaxValue"
-       [style.background]="_CurrentColor" [style.width]="_ProgressWidth+'%'"></div>
-  <span class="rst-progressBar__value">{{_Value}}%</span>
+       [style.background]="_CurrentProgressBarColor" [style.width]="_ProgressWidth+'%'"></div>
+  <span class="rst-progressBar__value" [style.color]="_CurrentProgressBarFontColor">{{_Value}}%</span>
 </div>
 

--- a/src/app/progress-bar/progress-bar.component.spec.ts
+++ b/src/app/progress-bar/progress-bar.component.spec.ts
@@ -38,7 +38,8 @@ describe('ProgressBarComponent', () => {
         component.Value = RandomValue;
         fixture.detectChanges();
         expect(
-          fixture.nativeElement.querySelector('.rst-progressBar__value').innerText,
+          fixture.nativeElement.querySelector('.rst-progressBar__value')
+            .innerText,
         ).toEqual(component._Value + '%');
       }
     });
@@ -54,11 +55,38 @@ describe('ProgressBarComponent', () => {
       expect(component._Value).toBe(0);
     });
 
-    it('should set _StandardMaxValue to false when Value is higher than 100', () => {
+    it('Value should be 0 when value is NaN', () => {
+      component.Value = NaN;
+      expect(component._Value).toBe(0);
+    });
+
+    it('should set _StandardMaxValue to false when MaxValue is higher than 100', () => {
       component.MaxValue = 200;
       component.ngOnInit();
       component.Value = 200;
       expect(component._StandardMaxValue).toBeFalsy();
+    });
+
+    it('should set _StandardMaxValue to false when MaxValue is less 100', () => {
+      component.MaxValue = 90;
+      component.ngOnInit();
+      component.Value = 85;
+      expect(component._StandardMaxValue).toBeFalsy();
+    });
+
+    it('should set _StandardMaxValue to true when MaxValue is 100', () => {
+      component.MaxValue = 100;
+      component.ngOnInit();
+      component.Value = 90;
+      expect(component._StandardMaxValue).toBeTruthy();
+    });
+
+    it('should throw error when _StandardMaxValue is 0', () => {
+      component.MaxValue = 0;
+      component.Value = 90;
+      expect(() => {
+        component.ngOnInit();
+      }).toThrow(new Error('Your Maxlevel is 0 and causes Divison 0 ERROR'));
     });
 
     it('should have the defined width of  < 100%  when _StandardMaxValue is set to false', () => {
@@ -80,28 +108,78 @@ describe('ProgressBarComponent', () => {
     });
     it('should have standard color green when no other color is set or default, custom zones are in use', () => {
       component.Value = 9;
-      expect(component._CurrentColor).toBe('green');
+      expect(component._CurrentProgressBarColor).toBe('lightblue');
     });
     it('should have the new color aqua when a new color is set', () => {
       component._Value = 52;
-      component.Color = 'aqua';
-      expect(component._CurrentColor).toBe('aqua');
+      component.ProgressBarColor = 'aqua';
+      expect(component._CurrentProgressBarColor).toBe('aqua');
     });
     it('color should be yellow when value is set to 40 and default zones are in use', () => {
       component.UseDefaultZones = true;
       component.Value = 40;
-      expect(component._CurrentColor).toBe('yellow');
+      expect(component._CurrentProgressBarColor).toBe('yellow');
     });
     it('color should be blue when custom zone on position 0 is used and value is 35', () => {
       const Customzones = [
-        { value: 50, color: 'blue' },
-        { value: 100, color: 'red' },
+        {
+          ProgressValue: 35,
+          ProgressColor: 'blue',
+          ProgressFontColor: 'white',
+        },
+        {
+          ProgressValue: 66,
+          ProgressColor: 'yellow',
+          ProgressFontColor: 'white',
+        },
+        {
+          ProgressValue: component.MaxValue,
+          ProgressColor: 'red',
+          ProgressFontColor: 'white',
+        },
       ];
       component.UseCustomZones = true;
       component.CustomZones = Customzones;
       component.ngOnInit();
       component.Value = 35;
-      expect(component._CurrentColor).toBe('blue');
+      expect(component._CurrentProgressBarColor).toBe('blue');
+    });
+
+    it('FontColor should be white when no zones are used', () => {
+      component.Value = 40;
+      expect(component._CurrentProgressBarFontColor).toBe('white');
+    });
+
+    it('FontColor should be black when defaultzones are used and value is 27', () => {
+      component.UseDefaultZones = true;
+      component.ngOnInit();
+      component.Value = 27;
+      expect(component._CurrentProgressBarFontColor).toBe('black');
+    });
+
+    it('FontColor should be white when custom zone on position 0 is used and value is 35', () => {
+      const Customzones = [
+        {
+          ProgressValue: 35,
+          ProgressColor: 'blue',
+          ProgressFontColor: 'white',
+        },
+        {
+          ProgressValue: 66,
+          ProgressColor: 'yellow',
+          ProgressFontColor: 'white',
+        },
+        {
+          ProgressValue: component.MaxValue,
+          ProgressColor: 'red',
+          ProgressFontColor: 'white',
+        },
+      ];
+      component.UseCustomZones = true;
+      component.CustomZones = Customzones;
+      component.ngOnInit();
+      component.Value = 35;
+      expect(component._CurrentProgressBarFontColor).toBe('white');
     });
     it('setColor method shouldnt called when there are no zones in use', () => {
       const spySetColor = spyOn(component, 'setColor');
@@ -134,8 +212,21 @@ describe('ProgressBarComponent', () => {
     });
     it('_ZonesInUse should use the CustomZones when CustomZones are set', () => {
       const CustomZones = [
-        { value: 50, color: 'green' },
-        { value: 100, color: 'red' },
+        {
+          ProgressValue: 33,
+          ProgressColor: 'green',
+          ProgressFontColor: 'white',
+        },
+        {
+          ProgressValue: 66,
+          ProgressColor: 'yellow',
+          ProgressFontColor: 'white',
+        },
+        {
+          ProgressValue: component.MaxValue,
+          ProgressColor: 'red',
+          ProgressFontColor: 'white',
+        },
       ];
       component.UseCustomZones = true;
       component.CustomZones = CustomZones;
@@ -144,9 +235,21 @@ describe('ProgressBarComponent', () => {
     });
     it('_ZonesInUse should use the DefaultZones when UseDefaultZones is set to true', () => {
       const DefaultZones = [
-        { value: 33, color: 'green' },
-        { value: 66, color: 'yellow' },
-        { value: component.MaxValue, color: 'red' },
+        {
+          ProgressValue: 33,
+          ProgressColor: 'green',
+          ProgressFontColor: 'black',
+        },
+        {
+          ProgressValue: 66,
+          ProgressColor: 'yellow',
+          ProgressFontColor: 'black',
+        },
+        {
+          ProgressValue: component.MaxValue,
+          ProgressColor: 'red',
+          ProgressFontColor: 'white',
+        },
       ];
       component.UseDefaultZones = true;
       component.ngOnInit();

--- a/src/app/progress-bar/progress-bar.component.ts
+++ b/src/app/progress-bar/progress-bar.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { RST_PBar_Zone } from './interface_progress-bar';
+import { RSTPBarZone } from './interface_progress-bar';
 
 @Component({
   selector: 'app-progress-bar',
@@ -9,17 +9,20 @@ import { RST_PBar_Zone } from './interface_progress-bar';
 export class ProgressBarComponent implements OnInit {
   _Value = 0;
   _StandardMaxValue = true;
+  _StandardProgressBarColor = 'lightblue';
+  _StandardProgressBarFontColor = 'white';
   _ProgressWidth = 0;
-  _CurrentColor = 'green';
-  _Zones: RST_PBar_Zone[];
-  _ZonesInUse: RST_PBar_Zone[];
+  _CurrentProgressBarColor = this._StandardProgressBarColor;
+  _CurrentProgressBarFontColor = this._StandardProgressBarFontColor;
+  _Zones: RSTPBarZone[];
+  _ZonesInUse: RSTPBarZone[];
 
   constructor() {}
 
   @Input() Name = 'rst-progressbar';
   @Input()
   set Value(Value: number) {
-    if (Value === null || typeof Value === 'undefined') {
+    if (Value === null || typeof Value === 'undefined' || isNaN(Value)) {
       this.onValueChange(0);
     } else {
       this.onValueChange(Value);
@@ -30,12 +33,20 @@ export class ProgressBarComponent implements OnInit {
   @Input() UseCustomZones = false;
   @Input() CustomZones;
   @Input()
-  set Color(Color: string) {
-    this._CurrentColor = Color;
+  set ProgressBarColor(Color: string) {
+    this._CurrentProgressBarColor = Color;
+  }
+  @Input()
+  set ProgressBarFontColor(Color: string) {
+    this._CurrentProgressBarFontColor = Color;
   }
   ngOnInit() {
     if (this.MaxValue !== 100) {
-      this._StandardMaxValue = false;
+      if (this.MaxValue > 0) {
+        this._StandardMaxValue = false;
+      } else {
+        throw new Error('Your Maxlevel is 0 and causes Divison 0 ERROR');
+      }
     }
     if (this.UseCustomZones) {
       this.generateCustomZones(this.CustomZones);
@@ -63,16 +74,18 @@ export class ProgressBarComponent implements OnInit {
   setColor(Value) {
     this._ZonesInUse.forEach((zone, ind) => {
       if (ind === 0) {
-        if (Value >= 0 && Value <= zone.value) {
-          this._CurrentColor = zone.color;
+        if (Value >= 0 && Value <= zone.ProgressValue) {
+          this._CurrentProgressBarColor = zone.ProgressColor;
+          this._CurrentProgressBarFontColor = zone.ProgressFontColor;
           return;
         }
       } else {
         if (
-          Value > this._ZonesInUse[ind - 1].value &&
-          Value <= this._ZonesInUse[ind].value
+          Value > this._ZonesInUse[ind - 1].ProgressValue &&
+          Value <= this._ZonesInUse[ind].ProgressValue
         ) {
-          this._CurrentColor = zone.color;
+          this._CurrentProgressBarColor = zone.ProgressColor;
+          this._CurrentProgressBarFontColor = zone.ProgressFontColor;
           return;
         }
       }
@@ -81,17 +94,25 @@ export class ProgressBarComponent implements OnInit {
 
   generateStandardZones() {
     this._Zones = [
-      { value: 33, color: 'green' },
-      { value: 66, color: 'yellow' },
-      { value: this.MaxValue, color: 'red' },
+      { ProgressValue: 33, ProgressColor: 'green', ProgressFontColor: 'black' },
+      {
+        ProgressValue: 66,
+        ProgressColor: 'yellow',
+        ProgressFontColor: 'black',
+      },
+      {
+        ProgressValue: this.MaxValue,
+        ProgressColor: 'red',
+        ProgressFontColor: 'white',
+      },
     ];
     this._ZonesInUse = this._Zones;
   }
 
-  generateCustomZones(CustomZones: RST_PBar_Zone[]) {
+  generateCustomZones(CustomZones: RSTPBarZone[]) {
     if (CustomZones !== null && typeof CustomZones !== 'undefined') {
-      if (CustomZones[CustomZones.length - 1].value !== this.MaxValue) {
-        CustomZones[CustomZones.length - 1].value = this.MaxValue;
+      if (CustomZones[CustomZones.length - 1].ProgressValue !== this.MaxValue) {
+        CustomZones[CustomZones.length - 1].ProgressValue = this.MaxValue;
         console.warn(
           'RST-COMPONENTS-PROGRESS-BAR: Your last configured Zone is not equal to the MaxValue, ' +
             'we changed the value to MaxLevel, please adjust your Zones',


### PR DESCRIPTION
Renamed the Interface
Added ProgressFontColor to RSTBarZone Interface
Changed Interface and Renamed all Values

--progress-bar.component.html
Added [style.color] to the span with .rst-progressBar__value

--progress-bar.component.spec.ts
Added Tests for NaN, FontColor and Zones

--progress-bar.component.ts
Changed all Variables due to Interface change
Added StandardProgressBarColor and StandardProgressBarFontColor
Added Input to set ProgressBarFontColor
Fixed Bug when MaxLevel was 0 and now it is throwing error due to division through 0
Fixed Bug when Value was NaN